### PR TITLE
Increase Oil Tanker capacity

### DIFF
--- a/prototypes/ships.lua
+++ b/prototypes/ships.lua
@@ -498,7 +498,7 @@ oil_tanker.joint_distance = 12
 
 
 oil_tanker.weight = 120000
-oil_tanker.capacity = 150000
+oil_tanker.capacity = 625000
 oil_tanker.max_speed = 0.12
 oil_tanker.air_resistance = 0.40
 


### PR DESCRIPTION
## Background
The current capacity of 150k fluid units is fairly small. If we apply
the same scaling as the cargo ship, we get a capacity of 625k.

## Rationale
I've been running with this for about a week, and I find that, given the speed and fuel consumption of both ships, and considering their real-life counterparts, giving them a fairly large capacity makes perfect sense.

They take a fair while to fill up at oil rigs, but that is normal. And I've found that unless the oil rig is just off your coast, it still takes as much, if not longer, for the tanker to make it to port. When a full tanker arrives, it has oil for a while. Which is how it should be.

Tankers don't scale like trains, where you can just chain more wagons for long-distance trains which will spend the majority of their time at (a fairly high) max speed on a straight rail.

My long-distance trains carry 960 stacks, or 560k fluid, at a speed of over 350km/h, for a point of comparison. Ships don't really make it past 20km/h.

In fact, I would even argue that 625k is still too small, and 1k stacks is too small for the cargo ship, but let's try this first.
