### PR TITLE
Fix surface being nil in onTileBuild

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -90,6 +90,12 @@ function onTileBuild(e)
 		else
 			surface =  e.robot.surface
 		end 
+
+		-- Fallback, just in case
+		if surface == nil then
+			surface = game.surfaces.nauvis
+		end
+
 		local old_tiles = {}
 		for _, tile in pairs(e.tiles) do
 			if not surface.can_place_entity{name = "tile_test_item", position = tile.position} 


### PR DESCRIPTION
When using Creative Mod with the Instant Blueprint setting enabled, surface will
be nil.

Solution: Fall back to Nauvis.